### PR TITLE
[Fix] Multiple routes for same method

### DIFF
--- a/Resource.php
+++ b/Resource.php
@@ -19,7 +19,7 @@ class Resource {
     }
 
     public function addCustomRoute($method, $path, callable $callback, Array $options = array()) {
-	if(!in_array($method, $this->_customRoutes)){
+	if(!in_array($method, array_keys($this->_customRoutes))){
 	    $this->_customRoutes[$method] = array();
 	}
 	$this->_customRoutes[$method][$path] = array(

--- a/Resource.php
+++ b/Resource.php
@@ -19,7 +19,7 @@ class Resource {
     }
 
     public function addCustomRoute($method, $path, callable $callback, Array $options = array()) {
-	if(!in_array($method, array_keys($this->_customRoutes))){
+	if(!array_key_exists($method, $this->_customRoutes)){
 	    $this->_customRoutes[$method] = array();
 	}
 	$this->_customRoutes[$method][$path] = array(


### PR DESCRIPTION
Allow multiple routes for the same method, without the array_keys the match always returns false and as it's inverted the array gets overriden.